### PR TITLE
#4: Introduce central NuGet package management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,10 @@
+﻿<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18"/>
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
+    </ItemGroup>
+</Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    </packageSources>
+    
+    <packageSourceCredentials />
+
+    <disabledPackageSources />
+
+    <packageRestore>
+        <add key="enabled" value="true" />
+        <add key="automatic" value="true" />
+    </packageRestore>
+    
+    <packageSourceMapping>
+        <packageSource key="nuget.org">
+            <package pattern="*" />
+        </packageSource>
+    </packageSourceMapping>
+</configuration>

--- a/src/MTGIM/MTGIM.csproj
+++ b/src/MTGIM/MTGIM.csproj
@@ -3,12 +3,11 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
 </Project>

--- a/src/MTGIM/Program.cs
+++ b/src/MTGIM/Program.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.


### PR DESCRIPTION
Introduced central NuGet package management to the MGTIM solution.
Added a NuGet.config file that contains configuration of applicable NuGet feeds.

CLOSES #4 